### PR TITLE
simplify loop that creates list of IPs for gcomm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
         box.vm.provision :ansible do |ansible|
           # Disable default limit to connect to all the boxes
           ansible.limit = "all"
-          ansible.sudo = true
+          ansible.become = true
           ansible.playbook = "galera.yml"
           ansible.groups = {
             "galera_cluster" => ["galera-db-1", "galera-db-2", "galera-db-3"]

--- a/roles/galera_conf/defaults/main.yml
+++ b/roles/galera_conf/defaults/main.yml
@@ -4,3 +4,5 @@ galera_wsrep_cluster_name: ansible_galera_cluster
 bootstrapped: no
 galera_sst_user: galera
 galera_sst_pass: galera
+galera_cluster_interface: eth1
+galera_cluster_interface_fact_var: ansible_{{ galera_cluster_interface }}

--- a/roles/galera_conf/templates/server.cnf.j2
+++ b/roles/galera_conf/templates/server.cnf.j2
@@ -11,11 +11,7 @@ datadir=/var/lib/mysql
 
 # Mandatory settings
 wsrep_provider=/usr/lib64/galera/libgalera_smm.so
-wsrep_cluster_address="gcomm://
-{%- for host in groups['galera_cluster'] -%}
-{{ hostvars[host].ansible_eth1.ipv4.address }}
-{%- if not loop.last -%},{%- endif -%}
-{%- endfor -%}"
+wsrep_cluster_address = "gcomm://{{ groups['galera_cluster'] | map('extract', hostvars, [galera_cluster_interface_fact_var,'ipv4','address']) | list | join(',') }}"
 wsrep_cluster_name={{ galera_wsrep_cluster_name }}
 wsrep_node_name={{ ansible_hostname }}
 wsrep_node_address={{ ansible_eth1.ipv4.address }}


### PR DESCRIPTION
- Replace loop my map filter introduced in Ansible 2.1
- Make interface name configurable using galera_cluster_interface var
  - fixes #1
- Update Vagrantfile: sudo -> become